### PR TITLE
Refactor pages

### DIFF
--- a/pages/account_created.page.js
+++ b/pages/account_created.page.js
@@ -8,14 +8,15 @@ class AccountCreationPage extends Page {
         super(page)
         this.page = page
         this.accCreatedMssg = accCreatedMssg;
+        this.continueBttn = continueBttn;
     }
 
-    async getAccCreatedMssg() {
-        return await super.getElement(accCreatedMssg)
-    }
-    async getContinueBttn() {
-        return await super.getElement(continueBttn)
-    }
+    // async getAccCreatedMssg() {
+    //     return await super.getElement(accCreatedMssg)
+    // }
+    // async getContinueBttn() {
+    //     return await super.getElement(continueBttn)
+    // }
     async clickContinueBttn() {
         return await super.clickElement(continueBttn)
     }

--- a/pages/account_created.page.js
+++ b/pages/account_created.page.js
@@ -7,21 +7,13 @@ class AccountCreationPage extends Page {
     constructor(page) {
         super(page)
         this.page = page
-        this.accCreatedMssg = accCreatedMssg;
-        this.continueBttn = continueBttn;
     }
 
-    // async getAccCreatedMssg() {
-    //     return await super.getElement(accCreatedMssg)
-    // }
-    // async getContinueBttn() {
-    //     return await super.getElement(continueBttn)
-    // }
     async clickContinueBttn() {
         return await super.clickElement(continueBttn)
     }
     async isAccountCreatedVisible() {
-        const isVisible = await this.page.isVisible(this.accCreatedMssg);
+        const isVisible = await this.page.isVisible(accCreatedMssg);
         return isVisible;
     }
 }

--- a/pages/account_deleted.page.js
+++ b/pages/account_deleted.page.js
@@ -7,20 +7,13 @@ class AccountDeletionPage extends Page {
     constructor(page) {
         super(page)
         this.page = page
-        this.accDeletedMssg = accDeletedMssg;
     }
 
-    // async getAccDeletedMssg() {
-    //     return await super.getElement(accDeletedMssg)
-    // }
-    // async getContinueBttn() {
-    //     return await super.getElement(continueBttn)
-    // }
     async clickContinueBttn() {
         return await super.clickElement(continueBttn)
     }
     async isAccountDeletedVisible() {
-        const isVisible = await this.page.isVisible(this.accDeletedMssg);
+        const isVisible = await this.page.isVisible(accDeletedMssg);
         return isVisible;
     }
 }

--- a/pages/account_deleted.page.js
+++ b/pages/account_deleted.page.js
@@ -10,12 +10,12 @@ class AccountDeletionPage extends Page {
         this.accDeletedMssg = accDeletedMssg;
     }
 
-    async getAccDeletedMssg() {
-        return await super.getElement(accDeletedMssg)
-    }
-    async getContinueBttn() {
-        return await super.getElement(continueBttn)
-    }
+    // async getAccDeletedMssg() {
+    //     return await super.getElement(accDeletedMssg)
+    // }
+    // async getContinueBttn() {
+    //     return await super.getElement(continueBttn)
+    // }
     async clickContinueBttn() {
         return await super.clickElement(continueBttn)
     }

--- a/pages/home.page.js
+++ b/pages/home.page.js
@@ -18,41 +18,6 @@ class HomePage extends Page {
         this.page = page
     }
 
-
-    // // Elements getters
-    // async getHomePageLogoBttn() {
-    //     return await super.getElement(homePageLogoBttn);
-    // }
-    // async getHeaderHomeBttn() {
-    //     return await super.getElement(headerHomeBttn);
-    // }
-    // async getHeaderProductsBttn() {
-    //     return await super.getElement(headerProductsBttn);
-    // }
-    // async getHeaderCartBttn() {
-    //     return await super.getElement(headerCartBttn);
-    // }
-    // async getHeaderSighnupLoginBttn() {
-    //     return await super.getElement(headerSighnupLoginBttn);
-    // }
-    // async getHeaderContactUsBttn() {
-    //     return await super.getElement(headerContactUsBttn);
-    // }
-    // async getSubscriptionEmailField() {
-    //     return await super.getElement(subscriptionEmailField);
-    // }
-    // async getSubscriptionBttn() {
-    //     return await super.getElement(subscriptionBttn);
-    // }
-    // async getHeaderLogoutBttn() {
-    //     return await super.getElement(headerLogoutBttn);
-    // }
-    // async getHeaderDeleteAccBttn() {
-    //     return await super.getElement(headerDeleteAccBttn);
-    // }
-    // async getUserStatus() {
-    //     return await super.getElement(userStatus);
-    // }
     // Elements click's
     async clickHomePageLogoBttn() {
         return await super.clickElement(homePageLogoBttn);
@@ -87,25 +52,21 @@ class HomePage extends Page {
     // Test methods
     async isHeaderLogoutBttnVisible() {
         const logoutBttn = await super.getElement(headerLogoutBttn);
-        // const logoutBttn = await this.getHeaderLogoutBttn();
         const isVisible = await logoutBttn.isVisible();
         return isVisible;
     }
     async isHeaderDeleteAccBttnVisible() {
         const deleteAccBttn = await super.getElement(headerDeleteAccBttn);
-        // const deleteAccBttn = await this.getHeaderDeleteAccBttn();
         const isVisible = await deleteAccBttn.isVisible();
         return isVisible;
     }
     async isUserStatusVisible() {
         const userStatusElement = await super.getElement(userStatus);
-        // const userStatus = await this.getUserStatus();
         const isVisible = await userStatusElement.isVisible();
         return isVisible;
     }
     async isUserStatusCorrect() {
         const userStatusElement = await super.getElement(userStatus);
-        // const userStatusElement = await this.getUserStatus();
         const userStatusText = await userStatusElement.textContent();
         const userName = process.env.SIGNUP_NAME;
         const expectedUserStatus = ' Logged in as ' + userName;

--- a/pages/home.page.js
+++ b/pages/home.page.js
@@ -19,40 +19,40 @@ class HomePage extends Page {
     }
 
 
-    // Elements getters
-    async getHomePageLogoBttn() {
-        return await super.getElement(homePageLogoBttn);
-    }
-    async getHeaderHomeBttn() {
-        return await super.getElement(headerHomeBttn);
-    }
-    async getHeaderProductsBttn() {
-        return await super.getElement(headerProductsBttn);
-    }
-    async getHeaderCartBttn() {
-        return await super.getElement(headerCartBttn);
-    }
-    async getHeaderSighnupLoginBttn() {
-        return await super.getElement(headerSighnupLoginBttn);
-    }
-    async getHeaderContactUsBttn() {
-        return await super.getElement(headerContactUsBttn);
-    }
-    async getSubscriptionEmailField() {
-        return await super.getElement(subscriptionEmailField);
-    }
-    async getSubscriptionBttn() {
-        return await super.getElement(subscriptionBttn);
-    }
-    async getHeaderLogoutBttn() {
-        return await super.getElement(headerLogoutBttn);
-    }
-    async getHeaderDeleteAccBttn() {
-        return await super.getElement(headerDeleteAccBttn);
-    }
-    async getUserStatus() {
-        return await super.getElement(userStatus);
-    }
+    // // Elements getters
+    // async getHomePageLogoBttn() {
+    //     return await super.getElement(homePageLogoBttn);
+    // }
+    // async getHeaderHomeBttn() {
+    //     return await super.getElement(headerHomeBttn);
+    // }
+    // async getHeaderProductsBttn() {
+    //     return await super.getElement(headerProductsBttn);
+    // }
+    // async getHeaderCartBttn() {
+    //     return await super.getElement(headerCartBttn);
+    // }
+    // async getHeaderSighnupLoginBttn() {
+    //     return await super.getElement(headerSighnupLoginBttn);
+    // }
+    // async getHeaderContactUsBttn() {
+    //     return await super.getElement(headerContactUsBttn);
+    // }
+    // async getSubscriptionEmailField() {
+    //     return await super.getElement(subscriptionEmailField);
+    // }
+    // async getSubscriptionBttn() {
+    //     return await super.getElement(subscriptionBttn);
+    // }
+    // async getHeaderLogoutBttn() {
+    //     return await super.getElement(headerLogoutBttn);
+    // }
+    // async getHeaderDeleteAccBttn() {
+    //     return await super.getElement(headerDeleteAccBttn);
+    // }
+    // async getUserStatus() {
+    //     return await super.getElement(userStatus);
+    // }
     // Elements click's
     async clickHomePageLogoBttn() {
         return await super.clickElement(homePageLogoBttn);
@@ -86,22 +86,26 @@ class HomePage extends Page {
     }
     // Test methods
     async isHeaderLogoutBttnVisible() {
-        const headerLogoutBttn = await this.getHeaderLogoutBttn();
-        const isVisible = await headerLogoutBttn.isVisible();
+        const logoutBttn = await super.getElement(headerLogoutBttn);
+        // const logoutBttn = await this.getHeaderLogoutBttn();
+        const isVisible = await logoutBttn.isVisible();
         return isVisible;
     }
     async isHeaderDeleteAccBttnVisible() {
-        const headerDeleteAccBttn = await this.getHeaderDeleteAccBttn();
-        const isVisible = await headerDeleteAccBttn.isVisible();
+        const deleteAccBttn = await super.getElement(headerDeleteAccBttn);
+        // const deleteAccBttn = await this.getHeaderDeleteAccBttn();
+        const isVisible = await deleteAccBttn.isVisible();
         return isVisible;
     }
     async isUserStatusVisible() {
-        const userStatus = await this.getUserStatus();
-        const isVisible = await userStatus.isVisible();
+        const userStatusElement = await super.getElement(userStatus);
+        // const userStatus = await this.getUserStatus();
+        const isVisible = await userStatusElement.isVisible();
         return isVisible;
     }
     async isUserStatusCorrect() {
-        const userStatusElement = await this.getUserStatus();
+        const userStatusElement = await super.getElement(userStatus);
+        // const userStatusElement = await this.getUserStatus();
         const userStatusText = await userStatusElement.textContent();
         const userName = process.env.SIGNUP_NAME;
         const expectedUserStatus = ' Logged in as ' + userName;

--- a/pages/signup.page.js
+++ b/pages/signup.page.js
@@ -34,7 +34,6 @@ class SignupPage extends Page {
     async fillAccountInformation() {
         // Fill Account Information fields based on the provided object
         await this.page.fill(this.locators.nameField, process.env.VALID_NAME);
-        // await this.page.fill(this.locators.emailField, process.env.VALID_EMAIL);
         await this.page.fill(this.locators.passwordField, process.env.VALID_PASSWORD);
         await this.pickDayOfBirth();
         await this.pickMonthOfBirth();

--- a/pages/signuplogin.page.js
+++ b/pages/signuplogin.page.js
@@ -15,31 +15,6 @@ class SignupLoginPage extends Page {
         this.page = page
     }
     
-    // // Elements getters
-    // async getLoginEmailAddressField() {
-    //     return await super.getElement(loginEmailAddressField);
-    // }
-    // async getLoginPasswordField() {
-    //     return await super.getElement(loginPasswordField);
-    // }
-    // async getLoginBttn() {
-    //     return await super.getElement(loginBttn);
-    // }
-    // async getSignupNameField() {
-    //     return await super.getElement(signupNameField);
-    // }
-    // async getSignupEmailAddressField() {
-    //     return await super.getElement(signupEmailAddressField);
-    // }
-    // async getSignupBttn() {
-    //     return await super.getElement(signupBttn);
-    // }
-    // async getLoginInfoLabel() {
-    //     return await super.getElement(loginInfoLabel);
-    // }
-    // async getSignupInfoLabel() {
-    //     return await super.getElement(signupInfoLabel);
-    // }
     // Elements click's
     async clickLoginEmailAddressField() {
         return await super.clickElement(loginEmailAddressField);
@@ -64,20 +39,16 @@ class SignupLoginPage extends Page {
     async enterNameAndEmail() {
         const nameField = await super.getElement(signupNameField);
         const emailField = await this.getElement(signupEmailAddressField);
-        // const nameField = await this.getSignupNameField();
-        // const emailField = await this.getSignupEmailAddressField();
         await nameField.fill(process.env.SIGNUP_NAME);
         await emailField.fill(process.env.SIGNUP_EMAIL);
     }
     async isLoginInfoLabelVisible() {
         const loginLabel = await super.getElement(loginInfoLabel);
-        // const loginInfoLabel = await this.getLoginInfoLabel();
         const isVisible = await loginLabel.isVisible();
         return isVisible;
     }
     async isSignupInfoLabelVisible() {
         const signupLabel = await super.getElement(signupInfoLabel);
-        // const signupInfoLabel = await this.getSignupInfoLabel();
         const isVisible = await signupLabel.isVisible();
         return isVisible;
     }

--- a/pages/signuplogin.page.js
+++ b/pages/signuplogin.page.js
@@ -15,31 +15,31 @@ class SignupLoginPage extends Page {
         this.page = page
     }
     
-    // Elements getters
-    async getLoginEmailAddressField() {
-        return await super.getElement(loginEmailAddressField);
-    }
-    async getLoginPasswordField() {
-        return await super.getElement(loginPasswordField);
-    }
-    async getLoginBttn() {
-        return await super.getElement(loginBttn);
-    }
-    async getSignupNameField() {
-        return await super.getElement(signupNameField);
-    }
-    async getSignupEmailAddressField() {
-        return await super.getElement(signupEmailAddressField);
-    }
-    async getSignupBttn() {
-        return await super.getElement(signupBttn);
-    }
-    async getLoginInfoLabel() {
-        return await super.getElement(loginInfoLabel);
-    }
-    async getSignupInfoLabel() {
-        return await super.getElement(signupInfoLabel);
-    }
+    // // Elements getters
+    // async getLoginEmailAddressField() {
+    //     return await super.getElement(loginEmailAddressField);
+    // }
+    // async getLoginPasswordField() {
+    //     return await super.getElement(loginPasswordField);
+    // }
+    // async getLoginBttn() {
+    //     return await super.getElement(loginBttn);
+    // }
+    // async getSignupNameField() {
+    //     return await super.getElement(signupNameField);
+    // }
+    // async getSignupEmailAddressField() {
+    //     return await super.getElement(signupEmailAddressField);
+    // }
+    // async getSignupBttn() {
+    //     return await super.getElement(signupBttn);
+    // }
+    // async getLoginInfoLabel() {
+    //     return await super.getElement(loginInfoLabel);
+    // }
+    // async getSignupInfoLabel() {
+    //     return await super.getElement(signupInfoLabel);
+    // }
     // Elements click's
     async clickLoginEmailAddressField() {
         return await super.clickElement(loginEmailAddressField);
@@ -62,19 +62,23 @@ class SignupLoginPage extends Page {
 
     // Test Methods
     async enterNameAndEmail() {
-        const nameField = await this.getSignupNameField();
-        const emailField = await this.getSignupEmailAddressField();
+        const nameField = await super.getElement(signupNameField);
+        const emailField = await this.getElement(signupEmailAddressField);
+        // const nameField = await this.getSignupNameField();
+        // const emailField = await this.getSignupEmailAddressField();
         await nameField.fill(process.env.SIGNUP_NAME);
         await emailField.fill(process.env.SIGNUP_EMAIL);
     }
     async isLoginInfoLabelVisible() {
-        const loginInfoLabel = await this.getLoginInfoLabel();
-        const isVisible = await loginInfoLabel.isVisible();
+        const loginLabel = await super.getElement(loginInfoLabel);
+        // const loginInfoLabel = await this.getLoginInfoLabel();
+        const isVisible = await loginLabel.isVisible();
         return isVisible;
     }
     async isSignupInfoLabelVisible() {
-        const signupInfoLabel = await this.getSignupInfoLabel();
-        const isVisible = await signupInfoLabel.isVisible();
+        const signupLabel = await super.getElement(signupInfoLabel);
+        // const signupInfoLabel = await this.getSignupInfoLabel();
+        const isVisible = await signupLabel.isVisible();
         return isVisible;
     }
 }


### PR DESCRIPTION
## Description of changes

This PR updates the pages classes to use the `getElement` method from the `page.js` file to get elements on the page instead of separate get methods for each element.

## Changes

- Replaced the methods for getting elements with the `getElement` method from the `page.js` file.
- Removed internal methods for getting elements for each page.

These changes simplify the page structure by using a common `getElement` method to get elements on the page, which makes it easier to maintain and save the code in the future.